### PR TITLE
Delete VaquaH inverter split AC product

### DIFF
--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 
 // Sample product data for search suggestions
 const productData = [
-  'VaquaH Inverter Split AC 1.5 Ton',
   'VaquaH Inverter Split AC 2 Ton',
   'VaquaH Window AC 1 Ton',
   'VaquaH Portable AC 1 Ton',


### PR DESCRIPTION
Remove 'VaquaH Inverter Split AC 1.5 Ton' from the product data as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-f90e51b3-b080-4c94-8323-ea0398c74ae0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f90e51b3-b080-4c94-8323-ea0398c74ae0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

