### PR TITLE
Fix offers firebase permission error

### DIFF
--- a/frontend/src/pages/admin/OffersAdmin.jsx
+++ b/frontend/src/pages/admin/OffersAdmin.jsx
@@ -24,15 +24,19 @@ const OffersAdmin = () => {
 
 	useEffect(() => {
 		(async () => {
-			if (!user) return;
+			// Short-circuit if no authenticated user
+			if (!user) {
+				setIsAdmin(false);
+				setLoading(false);
+				return;
+			}
 			setLoading(true);
 			setError(null);
 			try {
-				// Simple admin check: read own user doc role (already ensured by Auth flow)
-				const { adminService } = await import('@/services/adminService');
-				const status = await adminService.checkAdminStatus(user.uid);
-				setIsAdmin(!!status.isAdmin);
-				if (status.isAdmin) {
+				// Use role already resolved by AuthContext to avoid extra Firestore reads
+				const adminFlag = !!user.isAdmin;
+				setIsAdmin(adminFlag);
+				if (adminFlag) {
 					await loadOffers();
 				}
 			} catch (e) {
@@ -45,9 +49,15 @@ const OffersAdmin = () => {
 	}, [user]);
 
 	const loadOffers = async () => {
-		const q = query(collection(db, 'offers'), orderBy('createdAt', 'desc'));
-		const snap = await getDocs(q);
-		setOffers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+		try {
+			if (!isAdmin) return;
+			const q = query(collection(db, 'offers'), orderBy('createdAt', 'desc'));
+			const snap = await getDocs(q);
+			setOffers(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+		} catch (e) {
+			console.error('Load offers failed', e);
+			setError(e?.message || 'Failed to load offers');
+		}
 	};
 
 	const resetForm = () => {
@@ -57,6 +67,10 @@ const OffersAdmin = () => {
 
 	const saveOffer = async (e) => {
 		e.preventDefault();
+		if (!isAdmin) {
+			setError('Insufficient permissions');
+			return;
+		}
 		setSaving(true);
 		setError(null);
 		try {
@@ -89,6 +103,10 @@ const OffersAdmin = () => {
 	};
 
 	const removeOffer = async (id) => {
+		if (!isAdmin) {
+			setError('Insufficient permissions');
+			return;
+		}
 		try {
 			await deleteDoc(doc(db, 'offers', id));
 			await loadOffers();


### PR DESCRIPTION
Refactor `OffersAdmin.jsx` to use `AuthContext`'s `isAdmin` flag and guard Firestore operations to fix permission errors.

The previous implementation attempted to verify admin status by reading a user document from Firestore, which was failing due to permission issues. This change leverages the `isAdmin` flag already resolved by the `AuthContext` and ensures all Firestore read/write operations are only attempted if the user is confirmed as an administrator, preventing the "Missing or insufficient permissions" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-27eabe3f-183d-46d3-8eb1-3d2cbb10cd34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27eabe3f-183d-46d3-8eb1-3d2cbb10cd34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

