### PR TITLE
Integrate razorpay payments on hostinger

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -1,0 +1,11 @@
+RewriteEngine On
+# SPA fallback
+RewriteBase /
+RewriteRule ^index\.html$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(?!api/).* index.html [L]
+
+# API routes -> PHP files
+RewriteRule ^api/payments/razorpay/create-order$ api/create-order.php [L]
+RewriteRule ^api/payments/razorpay/verify$ api/verify.php [L]

--- a/public_html/api/create-order.php
+++ b/public_html/api/create-order.php
@@ -1,0 +1,66 @@
+<?php
+	header('Content-Type: application/json');
+	header('Cache-Control: no-store');
+
+	if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+		http_response_code(405);
+		echo json_encode(['error' => 'Method Not Allowed']);
+		exit;
+	}
+
+	// Read JSON body
+	$rawInput = file_get_contents('php://input');
+	$payload = json_decode($rawInput, true);
+	if (!is_array($payload)) {
+		http_response_code(400);
+		echo json_encode(['error' => 'Invalid JSON body']);
+		exit;
+	}
+
+	$amount = isset($payload['amount']) ? intval($payload['amount']) : 0; // amount in paise
+	$currency = isset($payload['currency']) ? strtoupper(trim($payload['currency'])) : 'INR';
+	$receipt = isset($payload['receipt']) ? (string)$payload['receipt'] : ('rcpt_' . uniqid());
+
+	if ($amount <= 0) {
+		http_response_code(400);
+		echo json_encode(['error' => 'Amount (in paise) must be > 0']);
+		exit;
+	}
+
+	// Razorpay credentials (server-side only)
+	$razorpayKeyId = 'rzp_test_R7RxkON5q04Q4G';
+	$razorpayKeySecret = 'jG290rNOiIq8DRRX0vrznonK';
+
+	// Build order payload
+	$orderData = [
+		'amount' => $amount,
+		'currency' => $currency,
+		'receipt' => $receipt,
+		'payment_capture' => 1,
+	];
+
+	$ch = curl_init('https://api.razorpay.com/v1/orders');
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_POST, true);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+	curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($orderData));
+	// Use basic auth
+	curl_setopt($ch, CURLOPT_USERPWD, $razorpayKeyId . ':' . $razorpayKeySecret);
+
+	$responseBody = curl_exec($ch);
+	$httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+	$curlErrNo = curl_errno($ch);
+	$curlErr = curl_error($ch);
+	curl_close($ch);
+
+	if ($curlErrNo) {
+		http_response_code(502);
+		echo json_encode(['error' => 'Curl error', 'details' => $curlErr]);
+		exit;
+	}
+
+	// Pass-through Razorpay response and status
+	http_response_code($httpStatus ?: 500);
+	echo $responseBody !== false ? $responseBody : json_encode(['error' => 'Empty response from Razorpay']);
+	exit;
+?>

--- a/public_html/api/verify.php
+++ b/public_html/api/verify.php
@@ -1,0 +1,42 @@
+<?php
+	header('Content-Type: application/json');
+	header('Cache-Control: no-store');
+
+	if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+		http_response_code(405);
+		echo json_encode(['error' => 'Method Not Allowed']);
+		exit;
+	}
+
+	$rawInput = file_get_contents('php://input');
+	$payload = json_decode($rawInput, true);
+	if (!is_array($payload)) {
+		http_response_code(400);
+		echo json_encode(['error' => 'Invalid JSON body']);
+		exit;
+	}
+
+	$orderId = isset($payload['order_id']) ? trim($payload['order_id']) : '';
+	$paymentId = isset($payload['payment_id']) ? trim($payload['payment_id']) : '';
+	$signature = isset($payload['signature']) ? trim($payload['signature']) : '';
+
+	if ($orderId === '' || $paymentId === '' || $signature === '') {
+		http_response_code(400);
+		echo json_encode(['error' => 'order_id, payment_id, signature are required']);
+		exit;
+	}
+
+	// Razorpay secret used to generate signature
+	$razorpayKeySecret = 'jG290rNOiIq8DRRX0vrznonK';
+
+	$generatedSignature = hash_hmac('sha256', $orderId . '|' . $paymentId, $razorpayKeySecret);
+
+	if (hash_equals($generatedSignature, $signature)) {
+		echo json_encode(['status' => 'ok']);
+		exit;
+	}
+
+	http_response_code(400);
+	echo json_encode(['status' => 'failed', 'error' => 'Signature mismatch']);
+	exit;
+?>


### PR DESCRIPTION
Add PHP endpoints and .htaccess rules for Razorpay payment processing on Hostinger to enable payments without a separate Node.js server.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3571b2a-b44e-47c8-8a19-c5f0c6bf6f8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3571b2a-b44e-47c8-8a19-c5f0c6bf6f8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

