### PR TITLE
Fix razorpay payment verification signature mismatch

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -114,5 +114,11 @@ service cloud.firestore {
       allow read: if true;
       allow write: if false;
     }
+
+    // Marketing assets collection (read-only for everyone)
+    match /marketingAssets/{docId} {
+      allow read: if true;
+      allow write: if isSignedIn() && isAdminCombined();
+    }
   }
 }

--- a/frontend/src/components/PaymentGateway.jsx
+++ b/frontend/src/components/PaymentGateway.jsx
@@ -88,12 +88,12 @@ const PaymentGateway = ({ amount, onSuccess, onCancel, disabled = false, disable
           try {
             const { orderService } = await import('@/services/orderService');
             const verification = await orderService.verifyRazorpayPayment({
-              razorpay_order_id: response.razorpay_order_id,
-              razorpay_payment_id: response.razorpay_payment_id,
-              razorpay_signature: response.razorpay_signature,
+              order_id: response.razorpay_order_id,
+              payment_id: response.razorpay_payment_id,
+              signature: response.razorpay_signature,
             });
             setLoading(false);
-            if (verification.valid) {
+            if (verification.status === 'ok') {
               onSuccess(response.razorpay_payment_id);
             } else {
               toast({

--- a/frontend/src/services/marketingService.js
+++ b/frontend/src/services/marketingService.js
@@ -26,7 +26,33 @@ export const marketingService = {
       return items;
     } catch (error) {
       console.error('Failed to load marketing services:', error);
-      return [];
+      // Return default services if Firebase fails
+      return [
+        {
+          id: 1,
+          title: 'AC Installation',
+          description: 'Professional AC installation services with warranty',
+          iconKey: 'zap',
+          link: '/services',
+          image: '/placeholder.svg'
+        },
+        {
+          id: 2,
+          title: 'AC Maintenance',
+          description: 'Regular maintenance to keep your AC running efficiently',
+          iconKey: 'rotate',
+          link: '/services',
+          image: '/placeholder.svg'
+        },
+        {
+          id: 3,
+          title: 'AC Repair',
+          description: 'Quick and reliable AC repair services',
+          iconKey: 'wrench',
+          link: '/services',
+          image: '/placeholder.svg'
+        }
+      ];
     }
   }
 };


### PR DESCRIPTION
Fix Firebase permissions for marketing services, correct Razorpay payment verification payload, and add fallback marketing services.

The Razorpay verification failed because the frontend was sending `razorpay_order_id`, `razorpay_payment_id`, and `razorpay_signature`, but the backend PHP script expected `order_id`, `payment_id`, and `signature`. This PR aligns the frontend payload with the backend's expectation. Additionally, default services are now provided if Firebase fails to load marketing assets, preventing an empty section.

---
<a href="https://cursor.com/background-agent?bcId=bc-6172a65b-cc7f-40fa-9bfd-32d5b94f38a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6172a65b-cc7f-40fa-9bfd-32d5b94f38a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

